### PR TITLE
load model on cpu and predict in non-labelled record

### DIFF
--- a/dosed/models/base.py
+++ b/dosed/models/base.py
@@ -3,7 +3,6 @@ import tempfile
 import json
 import shutil
 import numpy as np
-from torch import storage
 import torch
 import torch.nn as nn
 

--- a/minimum_example/train_and_evaluate_dosed.ipynb
+++ b/minimum_example/train_and_evaluate_dosed.ipynb
@@ -432,7 +432,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -443,5 +443,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -66,7 +66,7 @@ def test_dataset(signals, events, h5_directory, records):
         h5_directory=h5_directory,
         signals=signals,
         events=events,
-        records=records,
+        records=sorted(records),
         window=window,
         downsampling_rate=1,
         minimum_overlap=0.5,


### PR DESCRIPTION
Added 3 modifications, all of them in models/base.py:

1) Avoid function load() to crash is model to load was saved on GPU-compatible device. Now it will load always on CPU by default, but can be loaded on GPU if desired.

2) Function predict_dataset() gets the number of classes to predict from its parameter ´inference_dataset´, which in turn will get it from its attribute ´events´ (if provided when creating the dataset). During inference, no events are provided are there are no annotations. Now predict_dataset() will get the number of classes from the network and not from the dataset.

3) Function device() would return -1 in some occasions when called. Now it will just make sure that the 
returning object is instance of torch.device and otherwise return torch.device('cpu').